### PR TITLE
OS X Fixes

### DIFF
--- a/TheAmazingAudioEngine/Modules/Generation/AEAudioUnitInputModule.m
+++ b/TheAmazingAudioEngine/Modules/Generation/AEAudioUnitInputModule.m
@@ -58,6 +58,9 @@
         // We need to add a bridging retain, because the property is weak
         self.ioUnit = (__bridge AEIOAudioUnit*) CFBridgingRetain([AEIOAudioUnit new]);
         self.ioUnit.inputEnabled = YES;
+#if !TARGET_OS_IPHONE
+        self.ioUnit.outputEnabled = NO;
+#endif
         self.ioUnit.sampleRate = self.renderer.sampleRate;
         self.ownsIOUnit = YES;
     }

--- a/TheAmazingAudioEngine/Utilities/AEIOAudioUnit.m
+++ b/TheAmazingAudioEngine/Utilities/AEIOAudioUnit.m
@@ -118,39 +118,37 @@ NSString * const AEIOAudioUnitDidSetupNotification = @"AEIOAudioUnitDidSetupNoti
                                   0, &AEBufferStackMaxFramesPerSlice, sizeof(AEBufferStackMaxFramesPerSlice));
     AECheckOSStatus(result, "AudioUnitSetProperty(kAudioUnitProperty_MaximumFramesPerSlice)");
     
-#if TARGET_OS_IPHONE
-    // Enable/disable input
-    UInt32 flag = self.inputEnabled ? 1 : 0;
-    result = AudioUnitSetProperty(_audioUnit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &flag, sizeof(flag));
-    if ( !AECheckOSStatus(result, "AudioUnitSetProperty(kAudioOutputUnitProperty_EnableIO)") ) {
-        if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result
-                                              userInfo:@{ NSLocalizedDescriptionKey: @"Unable to enable/disable input" }];
-        return NO;
-    }
-    
-    // Enable/disable output
-    flag = self.outputEnabled ? 1 : 0;
-    result = AudioUnitSetProperty(_audioUnit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, 0, &flag, sizeof(flag));
-    if ( !AECheckOSStatus(result, "AudioUnitSetProperty(kAudioOutputUnitProperty_EnableIO)") ) {
-        if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result
-                                              userInfo:@{ NSLocalizedDescriptionKey: @"Unable to enable/disable output" }];
-        return NO;
-    }
-#endif
-    
-    if (TARGET_OS_IPHONE || self.outputEnabled) {
-        // Set the render callback
-        AURenderCallbackStruct rcbs = { .inputProc = AEIOAudioUnitRenderCallback, .inputProcRefCon = (__bridge void *)(self) };
-        result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Global, 0,
-                                      &rcbs, sizeof(rcbs));
-        if ( !AECheckOSStatus(result, "AudioUnitSetProperty(kAudioUnitProperty_SetRenderCallback)") ) {
+    if (TARGET_OS_IPHONE || !self.outputEnabled) {
+        // Enable/disable input
+        UInt32 flag = self.inputEnabled ? 1 : 0;
+        result = AudioUnitSetProperty(_audioUnit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &flag, sizeof(flag));
+        if ( !AECheckOSStatus(result, "AudioUnitSetProperty(kAudioOutputUnitProperty_EnableIO)") ) {
             if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result
-                                                  userInfo:@{ NSLocalizedDescriptionKey: @"Unable to configure output render" }];
+                                                  userInfo:@{ NSLocalizedDescriptionKey: @"Unable to enable/disable input" }];
+            return NO;
+        }
+        
+        // Enable/disable output
+        flag = self.outputEnabled ? 1 : 0;
+        result = AudioUnitSetProperty(_audioUnit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, 0, &flag, sizeof(flag));
+        if ( !AECheckOSStatus(result, "AudioUnitSetProperty(kAudioOutputUnitProperty_EnableIO)") ) {
+            if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result
+                                                  userInfo:@{ NSLocalizedDescriptionKey: @"Unable to enable/disable output" }];
             return NO;
         }
     }
     
-    if (TARGET_OS_IPHONE || self.inputEnabled) {
+    // Set the render callback
+    AURenderCallbackStruct rcbs = { .inputProc = AEIOAudioUnitRenderCallback, .inputProcRefCon = (__bridge void *)(self) };
+    result = AudioUnitSetProperty(_audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Global, 0,
+                                  &rcbs, sizeof(rcbs));
+    if ( !AECheckOSStatus(result, "AudioUnitSetProperty(kAudioUnitProperty_SetRenderCallback)") ) {
+        if ( error ) *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:result
+                                              userInfo:@{ NSLocalizedDescriptionKey: @"Unable to configure output render" }];
+        return NO;
+    }
+    
+    if (TARGET_OS_IPHONE || !self.outputEnabled) {
         // Set the input callback
         AURenderCallbackStruct inRenderProc;
         inRenderProc.inputProc = &AEIOAudioUnitInputCallback;

--- a/TheAmazingAudioEngine/Utilities/AEIOAudioUnit.m
+++ b/TheAmazingAudioEngine/Utilities/AEIOAudioUnit.m
@@ -637,7 +637,7 @@ static void AEIOAudioUnitStreamFormatChanged(void *inRefCon, AudioUnit inUnit, A
     AudioStreamBasicDescription asbd;
     UInt32 size = sizeof(asbd);
     AudioObjectPropertyAddress addr = { kAudioDevicePropertyStreamFormat, scope, 0 };
-    if ( !AECheckOSStatus(AudioObjectGetPropertyData(deviceId, &addr, 0, NULL, &size, &deviceId),
+    if ( !AECheckOSStatus(AudioObjectGetPropertyData(deviceId, &addr, 0, NULL, &size, &asbd),
                           "AudioObjectGetPropertyData") ) {
         return (AudioStreamBasicDescription){};
     }

--- a/TheAmazingAudioEngine/Utilities/AEIOAudioUnit.m
+++ b/TheAmazingAudioEngine/Utilities/AEIOAudioUnit.m
@@ -118,7 +118,7 @@ NSString * const AEIOAudioUnitDidSetupNotification = @"AEIOAudioUnitDidSetupNoti
                                   0, &AEBufferStackMaxFramesPerSlice, sizeof(AEBufferStackMaxFramesPerSlice));
     AECheckOSStatus(result, "AudioUnitSetProperty(kAudioUnitProperty_MaximumFramesPerSlice)");
     
-    if (TARGET_OS_IPHONE || !self.outputEnabled) {
+    if ( TARGET_OS_IPHONE || !self.outputEnabled ) {
         // Enable/disable input
         UInt32 flag = self.inputEnabled ? 1 : 0;
         result = AudioUnitSetProperty(_audioUnit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &flag, sizeof(flag));
@@ -148,7 +148,7 @@ NSString * const AEIOAudioUnitDidSetupNotification = @"AEIOAudioUnitDidSetupNoti
         return NO;
     }
     
-    if (TARGET_OS_IPHONE || !self.outputEnabled) {
+    if ( TARGET_OS_IPHONE || !self.outputEnabled ) {
         // Set the input callback
         AURenderCallbackStruct inRenderProc;
         inRenderProc.inputProc = &AEIOAudioUnitInputCallback;


### PR DESCRIPTION
This fixes a few issues with the OS X version of TAAE2. With these changes, I was able to get a basic Mac app working.

The first fix is in `-[AEIOAudioUnit streamFormatForDefaultDeviceScope:]`, it was trying write an `AudioStreamBasicDescription` into an `AudioDeviceID` (likely because it was copy-pasted from the method above it).

The second fix guards out certain parts of `-[AEIOAudioUnit setup:]` that don't apply on OS X. It skips setting `kAudioOutputUnitProperty_EnableIO` (only applies to AURemoteIO unit on iOS) and skips setting the render callback or input callback, depending on whether we're setting up for input or output. I'm not sure if the conditions I'm using are ideal (`if (TARGET_OS_IPHONE || self.outputEnabled)` etc), so that might need to be tweaked to always check for input/output enabled, even on iOS.
