### PR TITLE
Update AENewTimePitchModule enablePeakLocking parameter

### DIFF
--- a/Tests/AENewTimePitchModuleTests.m
+++ b/Tests/AENewTimePitchModuleTests.m
@@ -1,0 +1,68 @@
+//
+//  AENewTimePitchModuleTests.m
+//  TheAmazingAudioEngine
+//
+//  Created by Mark Anderson on 9/24/16.
+//  Copyright © 2016 A Tasty Pixel. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "AENewTimePitchModule.h"
+#import "AEManagedValue.h"
+#import "AEAudioBufferListUtilities.h"
+
+@interface AENewTimePitchModuleTests : XCTestCase
+
+@end
+
+@implementation AENewTimePitchModuleTests
+
+- (void)testDefaultParameterValues {
+    AERenderer * renderer = [AERenderer new];
+    AERenderer * subrenderer = [AERenderer new];
+    
+    AENewTimePitchModule * timePitchModule = [[AENewTimePitchModule alloc] initWithRenderer:renderer subrenderer:subrenderer];
+
+    XCTAssertEqual(timePitchModule.pitch, 0.0);
+    XCTAssertEqual(timePitchModule.rate, 1.0);
+    XCTAssertEqual(timePitchModule.overlap, 8.0);
+    XCTAssertEqual(timePitchModule.enablePeakLocking, YES);
+}
+
+- (void)testParameterValueManipulation {
+    AERenderer * renderer = [AERenderer new];
+    AERenderer * subrenderer = [AERenderer new];
+
+    AENewTimePitchModule * timePitchModule = [[AENewTimePitchModule alloc] initWithRenderer:renderer subrenderer:subrenderer];
+
+    AEManagedValue * timePitchValue = [AEManagedValue new];
+    timePitchValue.objectValue = timePitchModule;
+
+    double pitchChange = -2400.0;
+    double rateChange = 1.0/32.0;
+    double overlapChange = 32.0;
+    double enablePeakLockingChange = NO;
+
+    renderer.block = ^(const AERenderContext * context) {
+        __unsafe_unretained AENewTimePitchModule * timePitch
+        = (__bridge AENewTimePitchModule *)AEManagedValueGetValue(timePitchValue);
+
+        timePitch.pitch = pitchChange;
+        timePitch.rate = rateChange;
+        timePitch.overlap = overlapChange;
+        timePitch.enablePeakLocking = enablePeakLockingChange;
+    };
+
+    UInt32 frames = 1;
+    AudioBufferList * abl = AEAudioBufferListCreate(frames);
+    AudioTimeStamp timestamp = { .mFlags = kAudioTimeStampSampleTimeValid, .mSampleTime = 0 };
+
+    AERendererRun(renderer, abl, frames, &timestamp);
+
+    XCTAssertEqual(timePitchModule.pitch, pitchChange);
+    XCTAssertEqual(timePitchModule.rate, rateChange);
+    XCTAssertEqual(timePitchModule.overlap, overlapChange);
+    XCTAssertEqual(timePitchModule.enablePeakLocking, enablePeakLockingChange);
+}
+
+@end

--- a/TheAmazingAudioEngine.xcodeproj/project.pbxproj
+++ b/TheAmazingAudioEngine.xcodeproj/project.pbxproj
@@ -536,14 +536,14 @@
 			isa = PBXGroup;
 			children = (
 				4CDCACAA1CA25A6E008AAEF1 /* AEArrayTests.m */,
-				4C94E2851CAC9EAA006EB497 /* AEBufferStackTests.m */,
-				4C9F0FBD1CB339180032903E /* AEManagedValueTests.m */,
-				4CE5F4CA1CD3135800322F03 /* AECrossThreadMessagingTests.m */,
-				4C3183461CE8307A0085634F /* AEDSPUtilitiesTests.m */,
 				4C31835F1CEAE6830085634F /* AEAudioBufferListUtilitiesTests.m */,
 				4C43E5AF1CF14A340000DB62 /* AEAudioFileReadWriteTests.m */,
-				4CDCACAC1CA25A6E008AAEF1 /* Info.plist */,
+				4C94E2851CAC9EAA006EB497 /* AEBufferStackTests.m */,
+				4CE5F4CA1CD3135800322F03 /* AECrossThreadMessagingTests.m */,
+				4C3183461CE8307A0085634F /* AEDSPUtilitiesTests.m */,
+				4C9F0FBD1CB339180032903E /* AEManagedValueTests.m */,
 				2236604F1D96E34800CFA5B8 /* AENewTimePitchModuleTests.m */,
+				4CDCACAC1CA25A6E008AAEF1 /* Info.plist */,
 			);
 			path = Tests;
 			sourceTree = "<group>";

--- a/TheAmazingAudioEngine.xcodeproj/project.pbxproj
+++ b/TheAmazingAudioEngine.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		223660501D96E34800CFA5B8 /* AENewTimePitchModuleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2236604F1D96E34800CFA5B8 /* AENewTimePitchModuleTests.m */; };
 		4C3183101CDDEFDE0085634F /* AEMixerModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C31830E1CDDEFDE0085634F /* AEMixerModule.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4C3183111CDDEFDE0085634F /* AEMixerModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C31830E1CDDEFDE0085634F /* AEMixerModule.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4C3183121CDDEFDE0085634F /* AEMixerModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C31830E1CDDEFDE0085634F /* AEMixerModule.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -330,6 +331,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2236604F1D96E34800CFA5B8 /* AENewTimePitchModuleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AENewTimePitchModuleTests.m; sourceTree = "<group>"; };
 		4C31830E1CDDEFDE0085634F /* AEMixerModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEMixerModule.h; sourceTree = "<group>"; };
 		4C31830F1CDDEFDE0085634F /* AEMixerModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEMixerModule.m; sourceTree = "<group>"; };
 		4C3183161CDEC6560085634F /* AEAudioFileOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEAudioFileOutput.h; sourceTree = "<group>"; };
@@ -541,6 +543,7 @@
 				4C31835F1CEAE6830085634F /* AEAudioBufferListUtilitiesTests.m */,
 				4C43E5AF1CF14A340000DB62 /* AEAudioFileReadWriteTests.m */,
 				4CDCACAC1CA25A6E008AAEF1 /* Info.plist */,
+				2236604F1D96E34800CFA5B8 /* AENewTimePitchModuleTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1118,6 +1121,7 @@
 				4C43E5B01CF14A340000DB62 /* AEAudioFileReadWriteTests.m in Sources */,
 				4C3183601CEAE6830085634F /* AEAudioBufferListUtilitiesTests.m in Sources */,
 				4C9F0FBE1CB339180032903E /* AEManagedValueTests.m in Sources */,
+				223660501D96E34800CFA5B8 /* AENewTimePitchModuleTests.m in Sources */,
 				4CDCACAB1CA25A6E008AAEF1 /* AEArrayTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TheAmazingAudioEngine/Modules/Processing/AENewTimePitchModule.h
+++ b/TheAmazingAudioEngine/Modules/Processing/AENewTimePitchModule.h
@@ -38,14 +38,14 @@ extern "C" {
 //! range is from 1/32 to 32.0. Default is 1.0.
 @property (nonatomic) double rate;
 
-//! range is from -2400 cents to 2400 cents. Default is 1.0 cents.
+//! range is from -2400 cents to 2400 cents. Default is 0.0 cents.
 @property (nonatomic) double pitch;
 
 //! range is from 3.0 to 32.0. Default is 8.0.
 @property (nonatomic) double overlap;
 
-//! value is either 0 or 1. Default is 1.
-@property (nonatomic) double enablePeakLocking;
+//! value is either YES or NO. Default is YES.
+@property (nonatomic) BOOL enablePeakLocking;
 
 @end
 

--- a/TheAmazingAudioEngine/Modules/Processing/AENewTimePitchModule.m
+++ b/TheAmazingAudioEngine/Modules/Processing/AENewTimePitchModule.m
@@ -48,7 +48,7 @@
     return [self getParameterValueForId:kNewTimePitchParam_Overlap];
 }
 
-- (double)enablePeakLocking {
+- (BOOL)enablePeakLocking {
     return [self getParameterValueForId:kNewTimePitchParam_EnablePeakLocking];
 }
 
@@ -70,7 +70,7 @@
                       forId: kNewTimePitchParam_Overlap];
 }
 
-- (void)setEnablePeakLocking:(double)enablePeakLocking {
+- (void)setEnablePeakLocking:(BOOL)enablePeakLocking {
     [self setParameterValue: enablePeakLocking
                       forId: kNewTimePitchParam_EnablePeakLocking];
 }


### PR DESCRIPTION
- Updated the AENewTimePitchModule enablePeakLocking type to BOOL
- Add tests to verify that values are updated correctly in the renderer block
- Update documentation to reflect _actual_ pitch default parameter value post-initialization
