### PR TITLE
Notify rate change even when stopped

### DIFF
--- a/TheAmazingAudioEngine/Utilities/AEIOAudioUnit.m
+++ b/TheAmazingAudioEngine/Utilities/AEIOAudioUnit.m
@@ -622,6 +622,9 @@ static void AEIOAudioUnitIAAConnectionChanged(void *inRefCon, AudioUnit inUnit, 
         if ( rateChanged && running ) {
             AECheckOSStatus(AudioOutputUnitStop(_audioUnit), "AudioOutputUnitStop");
             stoppedUnit = YES;
+        }
+
+        if ( rateChanged ) {
             hasChanges = YES;
         }
         


### PR DESCRIPTION
AEIOAudioUnit updateStreamFormat should generate a AEIOAudioUnitDidUpdateStreamFormatNotification whenever the stream format changes.

Currently it does not generate a notification in the case that:

output is enabled && the AEIOAudioUnit is not running && the sample rate changed && the number of channels did not change.

An example of when this can happen is on the iPhone 7, when switching from bluetooth or lightning headphones to the phone's speakers. (Note that iPhone 7 is unusual for an iPhone in that it has stereo speakers, so the number of channels does not change.)
