### PR TITLE
Fix crash when recorder module is initialized with nonnull renderer

### DIFF
--- a/TheAmazingAudioEngine/Modules/Taps/AEAudioFileRecorderModule.m
+++ b/TheAmazingAudioEngine/Modules/Taps/AEAudioFileRecorderModule.m
@@ -68,7 +68,7 @@
 
 - (void)setRenderer:(AERenderer *)renderer {
     [super setRenderer:renderer];
-    if ( renderer && !_audioFile ) {
+    if ( renderer && _path && !_audioFile ) {
         [self openFileForRecordingError:NULL];
     }
 }


### PR DESCRIPTION
This pull request fixes `AEAudioFileRecorderModule` crash when initialized with non-null renderer.

The bug was introduced on this commit: 555be33e12ae4209860766651bcbd31e843489a0