### PR TITLE
Fix observing KVO twice

### DIFF
--- a/TheAmazingAudioEngine/Modules/AEModule.m
+++ b/TheAmazingAudioEngine/Modules/AEModule.m
@@ -35,9 +35,6 @@ static void * kRendererOutputChannelsChanged = &kRendererOutputChannelsChanged;
 - (instancetype)initWithRenderer:(AERenderer *)renderer {
     if ( !(self = [super init]) ) return nil;
     self.renderer = renderer;
-    if ( self.renderer ) {
-        [self startObservingRenderer];
-    }
     return self;
 }
 


### PR DESCRIPTION
`startObservingRenderer` is called twice if renderer is non-null.
This causes a crash if an `AEModule`(observer) has been deallocated; not removing observer twice.